### PR TITLE
Add: Package podspec

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-native-smooth-phone-input",
   "version": "1.0.3",
   "description": "user friendly react-native phone input",
+  "homepage": "https://github.com/MacKentoch/react-native-smooth-phone-input",
   "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/react-native-smooth-phone-input.podspec
+++ b/react-native-smooth-phone-input.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/MacKentoch/react-native-smooth-phone-input.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
By adding this simple podspec file, the package is recognized during the `pod install` command. Even though the package might not have any native parts, this might be good.